### PR TITLE
Unify short and long flags into the same variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ const program_name = p.nextValue() orelse @panic("no executable name");
 ### Parsing boolean flags and positional arguments
 
 Once you have a parser you want to call `next()` in a loop.
-This returns a token which has four different possibilities:
+This returns a token which has three different possibilities:
 
 * `.flag` when it encounters a flag (e.g. `--verbose` or `-v`).
-  This flag has a `.name` field which contains the name of the flag (without the dashes) and `.kind` field if you need to distinguish between long and short flags.
+  This flag has a `.name` field which contains the name of the flag (without the dashes) and a `.kind` field if you need to distinguish between long and short flags.
+  There's also a helper function `flag.is(str)` to easily check the name of the field.
 * `.arg` when it encounters a positional argument.
 * `.unexpected_value` when it encounters an unexpected value.
   You should just quit the program with an error when this happens.
@@ -80,11 +81,11 @@ var arg: ?[]const u8 = null;
 while (p.next()) |token| {
     switch (token) {
         .flag => |flag| {
-            if (std.mem.eql(u8, "force", flag.name) or std.mem.eql(u8, "f", flag.name)) {
+            if (flag.is("force") or flag.is("f")) {
                 force = true;
-            } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
+            } else if (flag.is("verbose") or flag.is("v")) {
                 verbose = true;
-            } else if (std.mem.eql(u8, "version", flag.name)) {
+            } else if (flag.is("version")) {
                 std.debug.print("v1\n", .{});
                 std.os.exit(0);
             }
@@ -109,11 +110,11 @@ This returns an optional slice:
 while (p.next()) |token| {
     switch (token) {
         .flag => |flag| {
-            if (std.mem.eql(u8, "file", flag.name) or std.mem.eql(u8, "f", flag.name)) {
+            if (flag.is("file") or flag.is("f")) {
                 file = p.nextValue() orelse @panic("--file requires value");
-            } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
+            } else if (flag.is("verbose") or flag.is("v")) {
                 verbose = true;
-            } else if (std.mem.eql(u8, "version", flag.name)) {
+            } else if (flag.is("version")) {
                 std.debug.print("v1\n", .{});
                 std.os.exit(0);
             }

--- a/examples/ex1.zig
+++ b/examples/ex1.zig
@@ -21,11 +21,11 @@ pub fn main() !void {
     while (p.next()) |token| {
         switch (token) {
             .flag => |flag| {
-                if (std.mem.eql(u8, "force", flag.name) or std.mem.eql(u8, "f", flag.name)) {
+                if (flag.is("force") or flag.is("f")) {
                     force = true;
-                } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
+                } else if (flag.is("verbose") or flag.is("v")) {
                     verbose = true;
-                } else if (std.mem.eql(u8, "version", flag.name)) {
+                } else if (flag.is("version")) {
                     std.debug.print("v1\n", .{});
                     std.os.exit(0);
                 }

--- a/examples/ex1.zig
+++ b/examples/ex1.zig
@@ -20,21 +20,14 @@ pub fn main() !void {
 
     while (p.next()) |token| {
         switch (token) {
-            .long => |flag| {
-                if (std.mem.eql(u8, "force", flag)) {
+            .flag => |flag| {
+                if (std.mem.eql(u8, "force", flag.name) or std.mem.eql(u8, "f", flag.name)) {
                     force = true;
-                } else if (std.mem.eql(u8, "verbose", flag)) {
+                } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
                     verbose = true;
-                } else if (std.mem.eql(u8, "version", flag)) {
+                } else if (std.mem.eql(u8, "version", flag.name)) {
                     std.debug.print("v1\n", .{});
                     std.os.exit(0);
-                }
-            },
-            .short => |flag| {
-                switch (flag) {
-                    'v' => verbose = true,
-                    'f' => force = true,
-                    else => @panic("unknown flag"),
                 }
             },
             .arg => |val| {

--- a/examples/ex2.zig
+++ b/examples/ex2.zig
@@ -19,23 +19,14 @@ pub fn main() !void {
 
     while (p.next()) |token| {
         switch (token) {
-            .long => |flag| {
-                if (std.mem.eql(u8, "file", flag)) {
+            .flag => |flag| {
+                if (std.mem.eql(u8, "file", flag.name) or std.mem.eql(u8, "f", flag.name)) {
                     file = p.nextValue() orelse @panic("--file requires value");
-                } else if (std.mem.eql(u8, "verbose", flag)) {
+                } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
                     verbose = true;
-                } else if (std.mem.eql(u8, "version", flag)) {
+                } else if (std.mem.eql(u8, "version", flag.name)) {
                     std.debug.print("v1\n", .{});
                     std.os.exit(0);
-                }
-            },
-            .short => |flag| {
-                switch (flag) {
-                    'v' => verbose = true,
-                    'f' => {
-                        file = p.nextValue() orelse @panic("--file requires value");
-                    },
-                    else => @panic("unknown flag"),
                 }
             },
             .arg => @panic("unexpected argument"),

--- a/examples/ex2.zig
+++ b/examples/ex2.zig
@@ -20,11 +20,11 @@ pub fn main() !void {
     while (p.next()) |token| {
         switch (token) {
             .flag => |flag| {
-                if (std.mem.eql(u8, "file", flag.name) or std.mem.eql(u8, "f", flag.name)) {
+                if (flag.is("file") or flag.is("f")) {
                     file = p.nextValue() orelse @panic("--file requires value");
-                } else if (std.mem.eql(u8, "verbose", flag.name) or std.mem.eql(u8, "v", flag.name)) {
+                } else if (flag.is("verbose") or flag.is("v")) {
                     verbose = true;
-                } else if (std.mem.eql(u8, "version", flag.name)) {
+                } else if (flag.is("version")) {
                     std.debug.print("v1\n", .{});
                     std.os.exit(0);
                 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -8,6 +8,10 @@ pub const FlagType = enum {
 pub const Flag = struct {
     name: []const u8,
     kind: FlagType,
+
+    pub fn is(self: Flag, other: []const u8) bool {
+        return std.mem.eql(u8, self.name, other);
+    }
 };
 
 pub const Token = union(enum) {


### PR DESCRIPTION
This was inspired by this Reddit comment: https://www.reddit.com/r/Zig/comments/t778es/comment/hzh3o15/?utm_source=share&utm_medium=web2x&context=3

> Nice library, this is mostly what I want from an argument parser.
> 
> However, I think handling long and short args for the same option in separate code blocks would get on my nerves, so I might create my own anyways.

Instead of having separate variants for long/short we return a single `Flag` value. This makes it a lot easier to unify logic when you have both short and long flags for the same functionality.

This also made it possible to add a `Flag.is` helper function to simplify usage even further.