### PR TITLE
build.zig: changes for zig 0.12.0-dev.2727+fad5e7a99 (2024-02-13) + addModule

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,9 +1,12 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) !void {
+pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+
+    _ = b.addModule("parg", .{
+        .root_source_file = .{ .path = "src/parser.zig" },
+    });
 
     const tests = b.addTest(.{
         .root_source_file = .{ .path = "src/parser.zig" },


### PR DESCRIPTION
# Description

Updates `build.zig` for zig `0.12.0-dev.2727+fad5e7a99` (2024-02-13) and adds `addModule` so that `parg` can be depended upon via a `build.zig.zon` (see https://github.com/judofyr/zini/issues/1)